### PR TITLE
add: multi site scraping support

### DIFF
--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -1,17 +1,124 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 
-export async function scrapeRecipe(url: string) {
-  const { data: html } = await axios.get(url);
-  const $ = cheerio.load(html);
+type CheerioAPI = cheerio.CheerioAPI;
 
-  // 例：レシピ名と材料の抽出（サイトにより要調整）
+function scrapeKurashiru($: CheerioAPI) {
   const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-
-  $('ul.recipeIngredients__list li').each((_, el) => {
+  $('ul.recipeIngredients__list li').each((_: any, el: any) => {
     ingredients.push($(el).text().trim());
   });
-
   return { name, ingredients };
+}
+
+function scrapeCookpad($: CheerioAPI) {
+  const name = $('.recipe-title').first().text().trim() || $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient_name').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeDelishKitchen($: CheerioAPI) {
+  const name = $('.recipe-title').first().text().trim() || $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient-list__item').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeShirogohan($: CheerioAPI) {
+  const name = $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient-list li, .ingredient-list__item').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeKikkoman($: CheerioAPI) {
+  const name = $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeAjinomoto($: CheerioAPI) {
+  const name = $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeMizkan($: CheerioAPI) {
+  const name = $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeKyouNoRyouri($: CheerioAPI) {
+  const name = $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+function scrapeDefault($: CheerioAPI) {
+  const name = $('h1').first().text().trim();
+  const ingredients: string[] = [];
+  $('ul li').each((_: any, el: any) => {
+    ingredients.push($(el).text().trim());
+  });
+  return { name, ingredients };
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const { data } = await axios.get(url);
+  return data;
+}
+
+function getSiteType(url: string): string {
+  const hostname = new URL(url).hostname;
+  if (hostname.includes('kurashiru')) return 'kurashiru';
+  if (hostname.includes('cookpad')) return 'cookpad';
+  if (hostname.includes('delishkitchen')) return 'delishkitchen';
+  if (hostname.includes('shirogohan')) return 'shirogohan';
+  if (hostname.includes('kikkoman')) return 'kikkoman';
+  if (hostname.includes('ajinomoto')) return 'ajinomoto';
+  if (hostname.includes('mizkan')) return 'mizkan';
+  if (hostname.includes('kyounoryouri')) return 'kyounoryouri';
+  return 'default';
+}
+
+function extractRecipe(siteType: string, $: CheerioAPI) {
+  switch (siteType) {
+    case 'kurashiru': return scrapeKurashiru($);
+    case 'cookpad': return scrapeCookpad($);
+    case 'delishkitchen': return scrapeDelishKitchen($);
+    case 'shir0gohan': return scrapeShirogohan($);
+    case 'kikkoman': return scrapeKikkoman($);
+    case 'ajinomoto': return scrapeAjinomoto($);
+    case 'mizkan': return scrapeMizkan($);
+    case 'kyounoryouri': return scrapeKyouNoRyouri($);
+    default: return scrapeDefault($);
+  }
+}
+
+export async function scrapeRecipe(url: string) {
+  const html = await fetchHtml(url);
+  const $ = cheerio.load(html);
+  const siteType = getSiteType(url);
+  return extractRecipe(siteType, $);
 }

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -83,10 +83,15 @@ function scrapeMizkan($: CheerioAPI) {
 }
 
 function scrapeKyouNoRyouri($: CheerioAPI) {
-  const name = $('h1').first().text().trim();
+  const name = $('h1.ttl').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
-    ingredients.push($(el).text().trim());
+  $('#ingredients_list dl').each((_: any, el: any) => {
+    const dt = $(el).find('dt');
+    const ingredientName = dt.find('span.ingredient').text().trim();
+    const quantity = dt.find('span.floatright').text().trim();
+    if (ingredientName) {
+      ingredients.push(quantity ? `${ingredientName} ${quantity}` : ingredientName);
+    }
   });
   return { name, ingredients };
 }

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -37,9 +37,9 @@ function scrapeCookpad($: CheerioAPI) {
 }
 
 function scrapeDelishKitchen($: CheerioAPI) {
-  const name = $('.recipe-title').first().text().trim() || $('h1').first().text().trim();
+  const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient-list__item').each((_: any, el: any) => {
+  $('ul.ingredient-list li').each((_: any, el: any) => {
     ingredients.push($(el).text().trim());
   });
   return { name, ingredients };
@@ -135,5 +135,6 @@ export async function scrapeRecipe(url: string) {
   const html = await fetchHtml(url);
   const $ = cheerio.load(html);
   const siteType = getSiteType(url);
+  console.log(`Scraping ${siteType} recipe from: ${url}`);
   return extractRecipe(siteType, $);
 }

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -13,10 +13,25 @@ function scrapeKurashiru($: CheerioAPI) {
 }
 
 function scrapeCookpad($: CheerioAPI) {
-  const name = $('.recipe-title').first().text().trim() || $('h1').first().text().trim();
+  const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient_name').each((_: any, el: any) => {
-    ingredients.push($(el).text().trim());
+  // 材料リストの各liをループ
+  $('.ingredient-list li').each((_: any, el: any) => {
+    // 材料名部分（aタグ複数＋span直下テキスト）
+    const names = [];
+    $(el).find('span a').each((_: any, a: any) => {
+      names.push($(a).text().trim());
+    });
+    // aタグ以外のspan直下テキスト（例: 「など」など）#3ではなど、のレアケース表示への対応はしない
+    const spanText = $(el).find('span').clone().children('a').remove().end().text().trim();
+    if (spanText) names.push(spanText);
+
+    // 分量部分
+    const quantity = $(el).find('bdi').text().trim();
+
+    // 材料名と分量を結合
+    const ingredient = names.join('・') + (quantity ? ` ${quantity}` : '');
+    ingredients.push(ingredient);
   });
   return { name, ingredients };
 }

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -6,7 +6,7 @@ type CheerioAPI = cheerio.CheerioAPI;
 function scrapeKurashiru($: CheerioAPI) {
   const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('ul.recipeIngredients__list li').each((_: any, el: any) => {
+  $('ul.ingredient-list li').each((_: any, el: any) => {
     ingredients.push($(el).text().trim());
   });
   return { name, ingredients };

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -45,10 +45,10 @@ function scrapeDelishKitchen($: CheerioAPI) {
   return { name, ingredients };
 }
 
-function scrapeShirogohan($: CheerioAPI) {
+function scrapeSirogohan($: CheerioAPI) {
   const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient-list li, .ingredient-list__item').each((_: any, el: any) => {
+  $('.material-halfbox li').each((_: any, el: any) => {
     ingredients.push($(el).text().trim());
   });
   return { name, ingredients };
@@ -109,7 +109,7 @@ function getSiteType(url: string): string {
   if (hostname.includes('kurashiru')) return 'kurashiru';
   if (hostname.includes('cookpad')) return 'cookpad';
   if (hostname.includes('delishkitchen')) return 'delishkitchen';
-  if (hostname.includes('shirogohan')) return 'shirogohan';
+  if (hostname.includes('sirogohan')) return 'sirogohan';
   if (hostname.includes('kikkoman')) return 'kikkoman';
   if (hostname.includes('ajinomoto')) return 'ajinomoto';
   if (hostname.includes('mizkan')) return 'mizkan';
@@ -122,7 +122,7 @@ function extractRecipe(siteType: string, $: CheerioAPI) {
     case 'kurashiru': return scrapeKurashiru($);
     case 'cookpad': return scrapeCookpad($);
     case 'delishkitchen': return scrapeDelishKitchen($);
-    case 'shir0gohan': return scrapeShirogohan($);
+    case 'sirogohan': return scrapeSirogohan($);
     case 'kikkoman': return scrapeKikkoman($);
     case 'ajinomoto': return scrapeAjinomoto($);
     case 'mizkan': return scrapeMizkan($);

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -75,8 +75,9 @@ function scrapeAjinomoto($: CheerioAPI) {
 function scrapeMizkan($: CheerioAPI) {
   const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
-    ingredients.push($(el).text().trim());
+  $('.recipeTopAbout_ingredients li').each((_: any, el: any) => {
+    const text = $(el).text().trim();
+    if (text) ingredients.push(text);
   });
   return { name, ingredients };
 }

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -57,7 +57,7 @@ function scrapeSirogohan($: CheerioAPI) {
 function scrapeKikkoman($: CheerioAPI) {
   const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
+  $('ul.recipe-detail-ingredient__list li').each((_: any, el: any) => {
     ingredients.push($(el).text().trim());
   });
   return { name, ingredients };

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -17,20 +17,18 @@ function scrapeCookpad($: CheerioAPI) {
   const ingredients: string[] = [];
   // 材料リストの各liをループ
   $('.ingredient-list li').each((_: any, el: any) => {
-    // 材料名部分（aタグ複数＋span直下テキスト）
-    const names = [];
-    $(el).find('span a').each((_: any, a: any) => {
-      names.push($(a).text().trim());
+    const names: string[] = [];
+    $(el).find('span').contents().each((_: any, node: any) => {
+      if (node.type === 'tag' && node.name === 'a') {
+        names.push($(node).text().trim());
+      } else if (node.type === 'text') {
+        const text = node.data.trim();
+        if (text) names.push(text);
+      }
     });
-    // aタグ以外のspan直下テキスト（例: 「など」など）#3ではなど、のレアケース表示への対応はしない
-    const spanText = $(el).find('span').clone().children('a').remove().end().text().trim();
-    if (spanText) names.push(spanText);
-
     // 分量部分
     const quantity = $(el).find('bdi').text().trim();
-
-    // 材料名と分量を結合
-    const ingredient = names.join('・') + (quantity ? ` ${quantity}` : '');
+    const ingredient = names.join('') + (quantity ? ` ${quantity}` : '');
     ingredients.push(ingredient);
   });
   return { name, ingredients };

--- a/backend/services/scraperService.ts
+++ b/backend/services/scraperService.ts
@@ -51,7 +51,7 @@ function scrapeKikkoman($: CheerioAPI) {
 function scrapeAjinomoto($: CheerioAPI) {
   const name = $('h1').first().text().trim();
   const ingredients: string[] = [];
-  $('.ingredient-list__item, .ingredient-list li').each((_: any, el: any) => {
+  $('ul.recipeIngredients__list li').each((_: any, el: any) => {
     ingredients.push($(el).text().trim());
   });
   return { name, ingredients };


### PR DESCRIPTION
## 概要
<!-- PRの背景・目的・概要 -->
主要なレシピサイトのスクレイピングに対応する

## 関連タスク
<!-- 関連するIssueやチケットのリンクを貼る。Issueの場合は、「#<IssueNumber>」でリンクできる -->
- #3 

## やったこと
<!-- このPRで何をしたのか？ -->
### クラシル
`ul.ingredient-list`配下の`li`要素の内容を材料とする

### クックパッド
`ingredient-list`クラス配下の`li`要素の内容で、`span`要素で細かく要素が分かれているので、再帰的に呼び出して内容を収集して材料とする
一部直書きで追記されている要素が後に一括して出てしまう内容は以下で対応
- #14
  - e00e4a0ebe7375bfcd19efefce574462b9108176


### DELISH KITCHEN
`ul.ingredient-list`配下の`li`要素の内容を材料とする

### 白ごはん.com
`material-halfbox`クラス配下の`li`要素の内容を材料とする

### キッコーマン
`ul.recipe-detail-ingredient__list`配下の`li`要素の内容を材料とする

### 味の素
`ul.recipeIngredients__list`配下の`li`要素の内容を材料とする

### ミツカン
`recipeTopAbout_ingredients`クラス配下の`li`要素の内容を材料とする

### きょうの料理
`ingredients_list`クラス配下の`dl`要素で`dl`を`find`し、`span`から情報を取得して材料とする


## 影響範囲
<!-- 影響を及ぼす範囲や他の機能への影響 -->


## テスト
<!-- テスト方法や結果 -->


## 備考
<!-- レビュワーへの伝達事項や残しておきたい情報 -->
